### PR TITLE
Removed Option in bbq! macro to now use MaybeUninit

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -667,7 +667,7 @@ macro_rules! unchecked_bbq {
             static mut BBQ: MaybeUninit<BBQueue> = MaybeUninit::uninit();
 
             BBQ = MaybeUninit::new(BBQueue::unpinned_new(&mut BUFFER));
-            unsafe { &mut *BBQ.as_mut_ptr() }
+            &mut *BBQ.as_mut_ptr()
         }
     }
 }


### PR DESCRIPTION
Minor optimization to not need the extra Option in the `bbq_unchecked!` macro