### PR TITLE
Made release `&mut self` to reflect its internal use

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -405,7 +405,7 @@ impl BBQueue {
     /// to be used by later writes
     ///
     /// If `used` is larger than the given grant, this function will panic.
-    pub fn release(&self, used: usize, grant: GrantR) {
+    pub fn release(&mut self, used: usize, grant: GrantR) {
         assert!(used <= grant.buf.len());
 
         // Verify we are committing OUR grant


### PR DESCRIPTION
I noticed that `release` was internally changing the `read` and `write_in_progress` fields, made the method take `&mut self` to reflect this.
Maybe there is a reason for the `&self` that I missed?