### PR TITLE
Allow the structure to be initialized as all zeros

### DIFF
--- a/core/src/cm_mutex.rs
+++ b/core/src/cm_mutex.rs
@@ -164,10 +164,10 @@ pub struct ConstBBBuffer<A> {
     read: usize,
 
     /// Used in the inverted case to mark the end of the
-    /// readable streak. Otherwise will == unsafe { self.buf.as_mut().len() }.
+    /// readable streak. Otherwise will == sizeof::<self.buf>().
     /// Writer is responsible for placing this at the correct
     /// place when entering an inverted condition, and Reader
-    /// is responsible for moving it back to unsafe { self.buf.as_mut().len() }
+    /// is responsible for moving it back to sizeof::<self.buf>()
     /// when exiting the inverted condition
     last: usize,
 
@@ -212,6 +212,16 @@ impl<A> ConstBBBuffer<A> {
             read: 0,
 
             /// Cooperatively owned
+            ///
+            /// NOTE: This should generally be initialized as size_of::<self.buf>(), however
+            /// this would prevent the structure from being entirely zero-initialized,
+            /// and can cause the .data section to be much larger than necessary. By
+            /// forcing the `last` pointer to be zero initially, we place the structure
+            /// in an "inverted" condition, which will be resolved on the first commited
+            /// bytes that are written to the structure.
+            ///
+            /// When read == last == write, no bytes will be allowed to be read (good), but
+            /// write grants can be given out (also good).
             last: 0,
 
             /// Owned by the Writer, "private"


### PR DESCRIPTION
This PR changes the structure initialization so that all fields can always initially be zero, and therefore reside entirely within .bss.

Notably, this changes the `last` tracking pointer to be initially zero, and tweaks the write commit logic to handle this gracefully.

Closes #43 

With this code:

```rust
static BUFFY: BBBuffer<U4096> = BBBuffer( ConstBBBuffer::new() );
```

Before:

```text
   text	   data	    bss	    dec	    hex	filename
  18934	   4136	      4	  23074	   5a22	timer-uart
```

After:

```text
   text	   data	    bss	    dec	    hex	filename
  18926	     16	   4120	  23062	   5a16	timer-uart
```

CC https://github.com/jonas-schievink/rubble/pull/100