### PR TITLE
Swap "writing" to "reading" for the GrantR struct documentation

### DIFF
--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -744,7 +744,7 @@ where
         self.buf = &self.buf[..len];
     }
 
-    /// Obtain access to the inner buffer for writing
+    /// Obtain access to the inner buffer for reading
     ///
     /// ```
     /// # // bbqueue test shim!


### PR DESCRIPTION
This is just a simple PR to fix a small documentation error.