### PR TITLE
Implement storing data in a pointer location

### DIFF
--- a/bbqtest/src/multi_thread.rs
+++ b/bbqtest/src/multi_thread.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(not(feature = "verbose"), allow(unused_variables))]
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer, ConstBBBuffer, Error};
+    use bbqueue::{consts::*, ArrayStorage, BBBuffer, ConstBBBuffer, Error, GenericArray};
     use rand::prelude::*;
     use std::thread::spawn;
     use std::time::{Duration, Instant};
@@ -14,7 +14,7 @@ mod tests {
     const RPT_IVAL: usize = ITERS / 100;
 
     // These two should be the same
-    type QueueSizeTy = U1024;
+    type QueueStorage = ArrayStorage<GenericArray<u8, U1024>>;
     const QUEUE_SIZE: usize = 1024;
 
     const TIMEOUT_NODATA: Duration = Duration::from_millis(10_000);
@@ -50,7 +50,7 @@ mod tests {
         #[cfg(feature = "verbose")]
         println!("RTX: Running test...");
 
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QueueStorage> = BBBuffer(ConstBBBuffer::new(ArrayStorage::new()));
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         let mut last_tx = Instant::now();
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QueueStorage> = BBBuffer(ConstBBBuffer::new(ArrayStorage::new()));
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         let mut last_tx = Instant::now();
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn sanity_check_grant_max() {
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QueueStorage> = BBBuffer(ConstBBBuffer::new(ArrayStorage::new()));
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         #[cfg(feature = "verbose")]

--- a/bbqtest/src/single_thread.rs
+++ b/bbqtest/src/single_thread.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer};
+    use bbqueue::{consts::*, ArrayStorage, BBBuffer, GenericArray};
 
     #[test]
     fn sanity_check() {
-        let bb: BBBuffer<U6> = BBBuffer::new();
+        let bb: BBBuffer<ArrayStorage<GenericArray<u8, U6>>> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
 
         const ITERS: usize = 100000;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,12 +21,12 @@
 //!
 //! ```rust, no_run
 //! # #[cfg(feature = "atomic")]
-//! # use bbqueue::atomic::{BBBuffer, consts::*};
+//! # use bbqueue::atomic::{ArrayStorage, BBBuffer, consts::*};
 //! # #[cfg(not(feature = "atomic"))]
-//! # use bbqueue::cm_mutex::{BBBuffer, consts::*};
-//! #
+//! # use bbqueue::cm_mutex::{ArrayStorage, BBBuffer, consts::*};
+//! # use bbqueue::GenericArray;
 //! // Create a buffer with six elements
-//! let bb: BBBuffer<U6> = BBBuffer::new();
+//! let bb: BBBuffer<ArrayStorage<GenericArray<u8, U6>>> = BBBuffer::new();
 //! let (mut prod, mut cons) = bb.try_split().unwrap();
 //!
 //! // Request space for one byte
@@ -53,12 +53,12 @@
 //!
 //! ```rust, no_run
 //! # #[cfg(feature = "atomic")]
-//! # use bbqueue::atomic::{BBBuffer, ConstBBBuffer, consts::*};
+//! # use bbqueue::atomic::{ArrayStorage, BBBuffer, ConstBBBuffer, consts::*};
 //! # #[cfg(not(feature = "atomic"))]
-//! # use bbqueue::cm_mutex::{BBBuffer, ConstBBBuffer, consts::*};
-//! #
+//! # use bbqueue::cm_mutex::{ArrayStorage, BBBuffer, ConstBBBuffer, consts::*};
+//! # use bbqueue::GenericArray;
 //! // Create a buffer with six elements
-//! static BB: BBBuffer<U6> = BBBuffer( ConstBBBuffer::new() );
+//! static BB: BBBuffer<ArrayStorage<GenericArray<u8, U6>>> = BBBuffer( ConstBBBuffer::new(ArrayStorage::new()) );
 //!
 //! fn main() {
 //!     // Split the bbqueue into producer and consumer halves.
@@ -131,7 +131,7 @@ mod vusize;
 
 use core::result::Result as CoreResult;
 
-pub use generic_array::ArrayLength;
+pub use generic_array::{ArrayLength, GenericArray};
 
 /// Result type used by the `BBQueue` interfaces
 pub type Result<T> = CoreResult<T, Error>;


### PR DESCRIPTION
cc #67 

This allows the `BBuffer` to use a pointed-to memory location rather than an owned array. Some use-cases would be shared-memory IPC, MMIO, or using a specific memory region on embedded. In my case, I want to use a 64KiB block SRAM for a DMA buffer on an STM32H7. It's not enough to just place the `BBuffer` there because I want the state variables to live in ITCM for speed, and I want to be able to use the whole buffer for data. There isn't an option for a typenum that's 2^16 - sizeof(BBuffer) so I can't even construct one of the right size currently.

I implemented this similar to other embedded libs I've seen by adding a `BBStorage` trait which is implemented by either a `PtrSorage` or an `ArrayStorage`. It worked out okay, but the ergonomics of the `ArrayStorage` suffer due to const fns being unable to return generic types. Perhaps someone can think of a solution.