### PR TITLE
Added split_read() function to be able to read all commited data at once

### DIFF
--- a/bbqtest/src/lib.rs
+++ b/bbqtest/src/lib.rs
@@ -390,6 +390,5 @@ mod tests {
         assert_eq!(rgrant.buf_first(), &[27]);
         assert_eq!(rgrant.buf_second(), &[]);
         rgrant.release(1);
-        
     }
 }

--- a/bbqtest/src/lib.rs
+++ b/bbqtest/src/lib.rs
@@ -340,8 +340,10 @@ mod tests {
 
         let rgrant = cons.split_read().unwrap();
         assert_eq!(rgrant.combined_len(), 10);
-        assert_eq!(rgrant.buf_first(), &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        assert_eq!(rgrant.buf_second(), &[]);
+        assert_eq!(
+            rgrant.bufs(),
+            (&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10][..], &[][..])
+        );
         // Release part of the buffer
         rgrant.release(6);
 
@@ -353,8 +355,10 @@ mod tests {
 
         let rgrant = cons.split_read().unwrap();
         assert_eq!(rgrant.combined_len(), 9);
-        assert_eq!(rgrant.buf_first(), &[7, 8, 9, 10]);
-        assert_eq!(rgrant.buf_second(), &[11, 12, 13, 14, 15]);
+        assert_eq!(
+            rgrant.bufs(),
+            (&[7, 8, 9, 10][..], &[11, 12, 13, 14, 15][..])
+        );
 
         // Release part of the buffer => | x | x | x | 14 | 15 | x | x | x | x | x |
         rgrant.release(7);
@@ -369,8 +373,7 @@ mod tests {
 
         let rgrant = cons.split_read().unwrap();
         assert_eq!(rgrant.combined_len(), 7);
-        assert_eq!(rgrant.buf_first(), &[14, 15, 21, 22, 23, 24, 25]);
-        assert_eq!(rgrant.buf_second(), &[]);
+        assert_eq!(rgrant.bufs(), (&[14, 15, 21, 22, 23, 24, 25][..], &[][..]));
         rgrant.release(0);
 
         // Fill buffer to the end => | 26 | 27 | x | 14 | 15 | 21 | 22 | 23 | 24 | 25 |
@@ -381,14 +384,15 @@ mod tests {
         // Fill buffer to the end => | x | 27 | x | x | x | x | x | x | x | x |
         let rgrant = cons.split_read().unwrap();
         assert_eq!(rgrant.combined_len(), 9);
-        assert_eq!(rgrant.buf_first(), &[14, 15, 21, 22, 23, 24, 25]);
-        assert_eq!(rgrant.buf_second(), &[26, 27]);
+        assert_eq!(
+            rgrant.bufs(),
+            (&[14, 15, 21, 22, 23, 24, 25][..], &[26, 27][..])
+        );
         rgrant.release(8);
 
         let rgrant = cons.split_read().unwrap();
         assert_eq!(rgrant.combined_len(), 1);
-        assert_eq!(rgrant.buf_first(), &[27]);
-        assert_eq!(rgrant.buf_second(), &[]);
+        assert_eq!(rgrant.bufs(), (&[27][..], &[][..]));
         rgrant.release(1);
     }
 }

--- a/bbqtest/src/lib.rs
+++ b/bbqtest/src/lib.rs
@@ -326,4 +326,70 @@ mod tests {
         }
         rgrant.release();
     }
+
+    #[test]
+    fn split_sanity_check() {
+        let bb: BBBuffer<U10> = BBBuffer::new();
+        let (mut prod, mut cons) = bb.try_split().unwrap();
+
+        // Fill buffer
+        let mut wgrant = prod.grant_exact(10).unwrap();
+        assert_eq!(wgrant.len(), 10);
+        wgrant.copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        wgrant.commit(10);
+
+        let rgrant = cons.split_read().unwrap();
+        assert_eq!(rgrant.combined_len(), 10);
+        assert_eq!(rgrant.buf_first(), &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(rgrant.buf_second(), &[]);
+        // Release part of the buffer
+        rgrant.release(6);
+
+        // Almost fill buffer again => | 11 | 12 | 13 | 14 | 15 | x | 7 | 8 | 9 | 10 |
+        let mut wgrant = prod.grant_exact(5).unwrap();
+        assert_eq!(wgrant.len(), 5);
+        wgrant.copy_from_slice(&[11, 12, 13, 14, 15]);
+        wgrant.commit(5);
+
+        let rgrant = cons.split_read().unwrap();
+        assert_eq!(rgrant.combined_len(), 9);
+        assert_eq!(rgrant.buf_first(), &[7, 8, 9, 10]);
+        assert_eq!(rgrant.buf_second(), &[11, 12, 13, 14, 15]);
+
+        // Release part of the buffer => | x | x | x | 14 | 15 | x | x | x | x | x |
+        rgrant.release(7);
+
+        // Check that it is not possible to claim more space than what should be available
+        assert!(prod.grant_exact(6).is_err());
+
+        // Fill buffer to the end => | x | x | x | 14 | 15 | 21 | 22 | 23 | 24 | 25 |
+        let mut wgrant = prod.grant_exact(5).unwrap();
+        wgrant.copy_from_slice(&[21, 22, 23, 24, 25]);
+        wgrant.commit(5);
+
+        let rgrant = cons.split_read().unwrap();
+        assert_eq!(rgrant.combined_len(), 7);
+        assert_eq!(rgrant.buf_first(), &[14, 15, 21, 22, 23, 24, 25]);
+        assert_eq!(rgrant.buf_second(), &[]);
+        rgrant.release(0);
+
+        // Fill buffer to the end => | 26 | 27 | x | 14 | 15 | 21 | 22 | 23 | 24 | 25 |
+        let mut wgrant = prod.grant_exact(2).unwrap();
+        wgrant.copy_from_slice(&[26, 27]);
+        wgrant.commit(2);
+
+        // Fill buffer to the end => | x | 27 | x | x | x | x | x | x | x | x |
+        let rgrant = cons.split_read().unwrap();
+        assert_eq!(rgrant.combined_len(), 9);
+        assert_eq!(rgrant.buf_first(), &[14, 15, 21, 22, 23, 24, 25]);
+        assert_eq!(rgrant.buf_second(), &[26, 27]);
+        rgrant.release(8);
+
+        let rgrant = cons.split_read().unwrap();
+        assert_eq!(rgrant.combined_len(), 1);
+        assert_eq!(rgrant.buf_first(), &[27]);
+        assert_eq!(rgrant.buf_second(), &[]);
+        rgrant.release(1);
+        
+    }
 }

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -626,7 +626,7 @@ where
         })
     }
 
-    /// Obtains up to two contiguous slices of committed bytes.
+    /// Obtains two disjoint slices, which are each contiguous of committed bytes.
     /// Combined these contain all previously commited data.
     pub fn split_read(&mut self) -> Result<SplitGrantR<'a, N>> {
         let inner = unsafe { &self.bbq.as_ref().0 };
@@ -1075,7 +1075,7 @@ where
         forget(self);
     }
 
-    /// Obtain access to the first inner buffer for reading
+    /// Obtain access to both inner buffers for reading
     ///
     /// ```
     /// # // bbqueue test shim!
@@ -1104,29 +1104,16 @@ where
     /// # bbqtest();
     /// # }
     /// ```
-    pub fn buf_first(&self) -> &[u8] {
-        self.buf1
+    pub fn bufs(&self) -> (&[u8], &[u8]) {
+        (self.buf1, self.buf2)
     }
 
-    /// Obtain access to the second inner buffer for reading
-    pub fn buf_second(&self) -> &[u8] {
-        self.buf2
-    }
-
-    /// Obtain mutable access to the first part of the read grant
+    /// Obtain mutable access to both parts of the read grant
     ///
     /// This is useful if you are performing in-place operations
     /// on an incoming packet, such as decryption
-    pub fn buf_mut_first(&mut self) -> &mut [u8] {
-        self.buf1
-    }
-
-    /// Obtain mutable access to the second part of the read grant
-    ///
-    /// This is useful if you are performing in-place operations
-    /// on an incoming packet, such as decryption
-    pub fn buf_mut_second(&mut self) -> &mut [u8] {
-        self.buf2
+    pub fn bufs_mut(&mut self) -> (&mut [u8], &mut [u8]) {
+        (self.buf1, self.buf2)
     }
 
     /// Sometimes, it's not possible for the lifetimes to check out. For example,

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -783,7 +783,7 @@ where
     pub(crate) to_release: usize,
 }
 
-/// A structure representing upt to two contiguous regions of memory that
+/// A structure representing up to two contiguous regions of memory that
 /// may be read from, and potentially "released" (or cleared)
 /// from the queue
 #[derive(Debug, PartialEq)]

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -1190,7 +1190,8 @@ where
         self.to_release = self.combined_len().min(amt);
     }
 
-    fn combined_len(&self) -> usize {
+    /// The combined length of both buffers
+    pub fn combined_len(&self) -> usize {
         self.buf1.len() + self.buf2.len()
     }
 }

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -1135,7 +1135,6 @@ where
             let _ = atomic::fetch_add(&inner.read, used, Release);
         } else {
             // Also release parts of the second buffer
-            //TODO: Check if this is sound
             inner.read.store(used - self.buf1.len(), Release);
         }
 

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -669,8 +669,13 @@ where
         // This is sound, as UnsafeCell, MaybeUninit, and GenericArray
         // are all `#[repr(Transparent)]
         let start_of_buf_ptr = inner.buf.get().cast::<u8>();
-        let grant_slice1 = unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(read as isize), sz1) };
-        let grant_slice2 = if sz2 > 0 { Some(unsafe { from_raw_parts_mut(start_of_buf_ptr, sz2) }) } else { None };
+        let grant_slice1 =
+            unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(read as isize), sz1) };
+        let grant_slice2 = if sz2 > 0 {
+            Some(unsafe { from_raw_parts_mut(start_of_buf_ptr, sz2) })
+        } else {
+            None
+        };
 
         Ok(SplitGrantR {
             buf1: grant_slice1,
@@ -1206,7 +1211,6 @@ where
         }
     }
 }
-
 
 impl<'a, N> Drop for GrantW<'a, N>
 where

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -1116,36 +1116,6 @@ where
         (self.buf1, self.buf2)
     }
 
-    /// Sometimes, it's not possible for the lifetimes to check out. For example,
-    /// if you need to hand this buffer to a function that expects to receive a
-    /// `&'static [u8]`, it is not possible for the inner reference to outlive the
-    /// grant itself.
-    ///
-    /// You MUST guarantee that in no cases, the reference that is returned here outlives
-    /// the grant itself. Once the grant has been released, referencing the data contained
-    /// WILL cause undefined behavior.
-    ///
-    /// Additionally, you must ensure that a separate reference to this data is not created
-    /// to this data, e.g. using `Deref` or the `buf()` method of this grant.
-    pub unsafe fn as_static_buf_first(&self) -> &'static [u8] {
-        transmute::<&[u8], &'static [u8]>(self.buf1)
-    }
-
-    /// Sometimes, it's not possible for the lifetimes to check out. For example,
-    /// if you need to hand this buffer to a function that expects to receive a
-    /// `&'static [u8]`, it is not possible for the inner reference to outlive the
-    /// grant itself.
-    ///
-    /// You MUST guarantee that in no cases, the reference that is returned here outlives
-    /// the grant itself. Once the grant has been released, referencing the data contained
-    /// WILL cause undefined behavior.
-    ///
-    /// Additionally, you must ensure that a separate reference to this data is not created
-    /// to this data, e.g. using `Deref` or the `buf()` method of this grant.
-    pub unsafe fn as_static_buf_second(&self) -> &'static [u8] {
-        transmute::<&[u8], &'static [u8]>(self.buf2)
-    }
-
     #[inline(always)]
     pub(crate) fn release_inner(&mut self, used: usize) {
         let inner = unsafe { &self.bbq.as_ref().0 };


### PR DESCRIPTION
Went ahead and implemented the idea I had in #76 myself.
There ~~are 3~~ is 1 TODOs left:
~~[1/2:](https://github.com/Sympatron/bbqueue/commit/ff88dce158ef51865b11209d4162ff9a36e8ddcf#diff-a5265a84d9c01902cc4066ea4ed1fa89da3ca7ed41fd9548f0809bbc248dbaaaR1132-R1136) I wrapped the second buffer in an `Option`, but that means I can't easily return it as `Option<&mut [u8]>` or `Option<&'static [u8]>` (`cannot move out of 'self.buf2'`')~~
[3:](https://github.com/Sympatron/bbqueue/commit/ff88dce158ef51865b11209d4162ff9a36e8ddcf#diff-a5265a84d9c01902cc4066ea4ed1fa89da3ca7ed41fd9548f0809bbc248dbaaaR1184-R1191) Since I don't really understand [this comment](https://github.com/Sympatron/bbqueue/commit/ff88dce158ef51865b11209d4162ff9a36e8ddcf#diff-a5265a84d9c01902cc4066ea4ed1fa89da3ca7ed41fd9548f0809bbc248dbaaaR1185), I am not sure if this is sound the way I implemented it. I think it is, but this comment irritates me.