### PR TITLE
Drop-in const generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ block of contiguous memory, which can be filled (or emptied) by a DMA engine.
 
 ```rust
 // Create a buffer with six elements
-let bb: BBBuffer<U6> = BBBuffer::new();
+let bb: BBBuffer<6> = BBBuffer::new();
 let (mut prod, mut cons) = bb.try_split().unwrap();
 
 // Request space for one byte
@@ -50,7 +50,7 @@ rgr.release(1);
 
 ```rust
 // Create a buffer with six elements
-static BB: BBBuffer<U6> = BBBuffer( ConstBBBuffer::new() );
+static BB: BBBuffer<6> = BBBuffer( ConstBBBuffer::new() );
 
 fn main() {
     // Split the bbqueue into producer and consumer halves.

--- a/bbqtest/Cargo.toml
+++ b/bbqtest/Cargo.toml
@@ -12,15 +12,13 @@ bounded-spsc-queue = { version = "0.4.0", optional = true }
 path = "../core"
 features = ["std"]
 
-[dependencies.generic-array]
-version = "0.12"
 
 [dev-dependencies]
 rand = "0.6"
 criterion = "0.3"
 crossbeam-utils = "0.7"
 crossbeam = "0.7"
-heapless = "0.5"
+heapless = "0.7"
 cfg-if = "0.1"
 
 [[bench]]

--- a/bbqtest/src/benches.rs
+++ b/bbqtest/src/benches.rs
@@ -1,4 +1,4 @@
-use bbqueue::{consts::*, BBBuffer};
+use bbqueue::BBBuffer;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::cmp::min;
 
@@ -17,7 +17,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("bbq 2048/4096", |bench| bench.iter(|| chunky(&data, 2048)));
 
-    let buffy: BBBuffer<U65536> = BBBuffer::new();
+    let buffy: BBBuffer<65536> = BBBuffer::new();
     let (mut prod, mut cons) = buffy.try_split().unwrap();
 
     c.bench_function("bbq 8192/65536", |bench| {
@@ -154,7 +154,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     use heapless::spsc::Queue;
 
-    let mut queue: Queue<[u8; 8192], U8> = Queue::new();
+    let mut queue: Queue<[u8; 8192], 8> = Queue::new();
     let (mut prod, mut cons) = queue.split();
 
     c.bench_function("heapless spsc::Queue 8192/65536", |bench| {
@@ -196,7 +196,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
 use crossbeam_utils::thread;
 fn chunky(data: &[u8], chunksz: usize) {
-    let buffy: BBBuffer<U4096> = BBBuffer::new();
+    let buffy: BBBuffer<4096> = BBBuffer::new();
     let (mut prod, mut cons) = buffy.try_split().unwrap();
 
     thread::scope(|sc| {

--- a/bbqtest/src/framed.rs
+++ b/bbqtest/src/framed.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer};
+    use bbqueue::BBBuffer;
 
     #[test]
     fn frame_wrong_size() {
-        let bb: BBBuffer<U256> = BBBuffer::new();
+        let bb: BBBuffer<256> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         // Create largeish grants
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn full_size() {
-        let bb: BBBuffer<U256> = BBBuffer::new();
+        let bb: BBBuffer<256> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
         let mut ctr = 0;
 
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn frame_overcommit() {
-        let bb: BBBuffer<U256> = BBBuffer::new();
+        let bb: BBBuffer<256> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         // Create largeish grants
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn frame_undercommit() {
-        let bb: BBBuffer<U512> = BBBuffer::new();
+        let bb: BBBuffer<512> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         for _ in 0..100_000 {
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn frame_auto_commit_release() {
-        let bb: BBBuffer<U256> = BBBuffer::new();
+        let bb: BBBuffer<256> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         for _ in 0..100 {

--- a/bbqtest/src/lib.rs
+++ b/bbqtest/src/lib.rs
@@ -8,11 +8,11 @@ mod single_thread;
 
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer, ConstBBBuffer, Error as BBQError};
+    use bbqueue::{BBBuffer, ConstBBBuffer, Error as BBQError};
 
     #[test]
     fn deref_deref_mut() {
-        let bb: BBBuffer<U6> = BBBuffer::new();
+        let bb: BBBuffer<6> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
 
         let mut wgr = prod.grant_exact(1).unwrap();
@@ -35,8 +35,8 @@ mod tests {
     #[test]
     fn static_allocator() {
         // Check we can make multiple static items...
-        static BBQ1: BBBuffer<U6> = BBBuffer(ConstBBBuffer::new());
-        static BBQ2: BBBuffer<U6> = BBBuffer(ConstBBBuffer::new());
+        static BBQ1: BBBuffer<6> = BBBuffer(ConstBBBuffer::new());
+        static BBQ2: BBBuffer<6> = BBBuffer(ConstBBBuffer::new());
         let (mut prod1, mut cons1) = BBQ1.try_split().unwrap();
         let (mut _prod2, mut cons2) = BBQ2.try_split().unwrap();
 
@@ -56,8 +56,8 @@ mod tests {
     #[test]
     fn release() {
         // Check we can make multiple static items...
-        static BBQ1: BBBuffer<U6> = BBBuffer(ConstBBBuffer::new());
-        static BBQ2: BBBuffer<U6> = BBBuffer(ConstBBBuffer::new());
+        static BBQ1: BBBuffer<6> = BBBuffer(ConstBBBuffer::new());
+        static BBQ2: BBBuffer<6> = BBBuffer(ConstBBBuffer::new());
         let (prod1, cons1) = BBQ1.try_split().unwrap();
         let (prod2, cons2) = BBQ2.try_split().unwrap();
 
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn direct_usage_sanity() {
         // Initialize
-        let bb: BBBuffer<U6> = BBBuffer::new();
+        let bb: BBBuffer<6> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
         assert_eq!(cons.read(), Err(BBQError::InsufficientSize));
 
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn zero_sized_grant() {
-        let bb: BBBuffer<U1000> = BBBuffer::new();
+        let bb: BBBuffer<1000> = BBBuffer::new();
         let (mut prod, mut _cons) = bb.try_split().unwrap();
 
         let size = 1000;
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn frame_sanity() {
-        let bb: BBBuffer<U1000> = BBBuffer::new();
+        let bb: BBBuffer<1000> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         // One frame in, one frame out
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn frame_wrap() {
-        let bb: BBBuffer<U22> = BBBuffer::new();
+        let bb: BBBuffer<22> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         // 10 + 1 used
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn frame_big_little() {
-        let bb: BBBuffer<U65536> = BBBuffer::new();
+        let bb: BBBuffer<65536> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split_framed().unwrap();
 
         // Create a frame that should take 3 bytes for the header
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn split_sanity_check() {
-        let bb: BBBuffer<U10> = BBBuffer::new();
+        let bb: BBBuffer<10> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
 
         // Fill buffer
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn split_read_sanity_check() {
-        let bb: BBBuffer<U6> = BBBuffer::new();
+        let bb: BBBuffer<6> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
 
         const ITERS: usize = 100000;

--- a/bbqtest/src/multi_thread.rs
+++ b/bbqtest/src/multi_thread.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(not(feature = "verbose"), allow(unused_variables))]
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer, ConstBBBuffer, Error};
+    use bbqueue::{BBBuffer, ConstBBBuffer, Error};
     use rand::prelude::*;
     use std::thread::spawn;
     use std::time::{Duration, Instant};
@@ -13,8 +13,6 @@ mod tests {
 
     const RPT_IVAL: usize = ITERS / 100;
 
-    // These two should be the same
-    type QueueSizeTy = U1024;
     const QUEUE_SIZE: usize = 1024;
 
     const TIMEOUT_NODATA: Duration = Duration::from_millis(10_000);
@@ -50,7 +48,7 @@ mod tests {
         #[cfg(feature = "verbose")]
         println!("RTX: Running test...");
 
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QUEUE_SIZE> = BBBuffer(ConstBBBuffer::new());
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         let mut last_tx = Instant::now();
@@ -142,7 +140,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QUEUE_SIZE> = BBBuffer(ConstBBBuffer::new());
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         let mut last_tx = Instant::now();
@@ -236,7 +234,7 @@ mod tests {
 
     #[test]
     fn sanity_check_grant_max() {
-        static BB: BBBuffer<QueueSizeTy> = BBBuffer(ConstBBBuffer::new());
+        static BB: BBBuffer<QUEUE_SIZE> = BBBuffer(ConstBBBuffer::new());
         let (mut tx, mut rx) = BB.try_split().unwrap();
 
         #[cfg(feature = "verbose")]

--- a/bbqtest/src/ring_around_the_senders.rs
+++ b/bbqtest/src/ring_around_the_senders.rs
@@ -1,14 +1,9 @@
 #[cfg(test)]
 mod tests {
 
-    use bbqueue::{
-        consts::*, ArrayLength, BBBuffer, ConstBBBuffer, Consumer, GrantR, GrantW, Producer,
-    };
+    use bbqueue::{BBBuffer, ConstBBBuffer, Consumer, GrantR, GrantW, Producer};
 
-    enum Potato<'a, N>
-    where
-        N: ArrayLength<u8>,
-    {
+    enum Potato<'a, const N: usize> {
         Tx((Producer<'a, N>, u8)),
         Rx((Consumer<'a, N>, u8)),
         TxG(GrantW<'a, N>),
@@ -26,12 +21,9 @@ mod tests {
     const TX_GRANTS_PER_RING: u8 = 3;
     const RX_GRANTS_PER_RING: u8 = 3;
     const BYTES_PER_GRANT: usize = 129;
-    type BufferSize = U4096;
+    const BUFFER_SIZE: usize = 4096;
 
-    impl<'a, N> Potato<'a, N>
-    where
-        N: ArrayLength<u8>,
-    {
+    impl<'a, const N: usize> Potato<'a, N> {
         fn work(self) -> (Self, Self) {
             match self {
                 Self::Tx((mut prod, ct)) => {
@@ -84,7 +76,7 @@ mod tests {
         }
     }
 
-    static BB: BBBuffer<BufferSize> = BBBuffer(ConstBBBuffer::new());
+    static BB: BBBuffer<BUFFER_SIZE> = BBBuffer(ConstBBBuffer::new());
 
     use std::sync::mpsc::{channel, Receiver, Sender};
     use std::thread::spawn;
@@ -95,20 +87,20 @@ mod tests {
 
         // create the channels
         let (tx_1_2, rx_1_2): (
-            Sender<Potato<'static, BufferSize>>,
-            Receiver<Potato<'static, BufferSize>>,
+            Sender<Potato<'static, BUFFER_SIZE>>,
+            Receiver<Potato<'static, BUFFER_SIZE>>,
         ) = channel();
         let (tx_2_3, rx_2_3): (
-            Sender<Potato<'static, BufferSize>>,
-            Receiver<Potato<'static, BufferSize>>,
+            Sender<Potato<'static, BUFFER_SIZE>>,
+            Receiver<Potato<'static, BUFFER_SIZE>>,
         ) = channel();
         let (tx_3_4, rx_3_4): (
-            Sender<Potato<'static, BufferSize>>,
-            Receiver<Potato<'static, BufferSize>>,
+            Sender<Potato<'static, BUFFER_SIZE>>,
+            Receiver<Potato<'static, BUFFER_SIZE>>,
         ) = channel();
         let (tx_4_1, rx_4_1): (
-            Sender<Potato<'static, BufferSize>>,
-            Receiver<Potato<'static, BufferSize>>,
+            Sender<Potato<'static, BUFFER_SIZE>>,
+            Receiver<Potato<'static, BUFFER_SIZE>>,
         ) = channel();
 
         tx_1_2.send(Potato::Tx((prod, 3))).unwrap();
@@ -116,7 +108,7 @@ mod tests {
 
         let thread_1 = spawn(move || {
             let mut count = TOTAL_RINGS;
-            let mut me: Potato<'static, BufferSize> = Potato::Idle;
+            let mut me: Potato<'static, BUFFER_SIZE> = Potato::Idle;
 
             loop {
                 if let Potato::Idle = me {
@@ -168,9 +160,9 @@ mod tests {
         });
 
         let closure_2_3_4 =
-            move |rx: Receiver<Potato<'static, BufferSize>>,
-                  tx: Sender<Potato<'static, BufferSize>>| {
-                let mut me: Potato<'static, BufferSize> = Potato::Idle;
+            move |rx: Receiver<Potato<'static, BUFFER_SIZE>>,
+                  tx: Sender<Potato<'static, BUFFER_SIZE>>| {
+                let mut me: Potato<'static, BUFFER_SIZE> = Potato::Idle;
                 let mut count = 0;
 
                 loop {

--- a/bbqtest/src/single_thread.rs
+++ b/bbqtest/src/single_thread.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use bbqueue::{consts::*, BBBuffer};
+    use bbqueue::BBBuffer;
 
     #[test]
     fn sanity_check() {
-        let bb: BBBuffer<U6> = BBBuffer::new();
+        let bb: BBBuffer<6> = BBBuffer::new();
         let (mut prod, mut cons) = bb.try_split().unwrap();
 
         const ITERS: usize = 100000;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,6 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-generic-array = "0.13"
 cortex-m = { version = "0.6.0", optional = true }
 
 [features]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,12 +21,12 @@
 //!
 //! ```rust, no_run
 //! # #[cfg(feature = "atomic")]
-//! # use bbqueue::atomic::{BBBuffer, consts::*};
+//! # use bbqueue::atomic::BBBuffer;
 //! # #[cfg(not(feature = "atomic"))]
-//! # use bbqueue::cm_mutex::{BBBuffer, consts::*};
+//! # use bbqueue::cm_mutex::BBBuffer;
 //! #
 //! // Create a buffer with six elements
-//! let bb: BBBuffer<U6> = BBBuffer::new();
+//! let bb: BBBuffer<6> = BBBuffer::new();
 //! let (mut prod, mut cons) = bb.try_split().unwrap();
 //!
 //! // Request space for one byte
@@ -53,12 +53,12 @@
 //!
 //! ```rust, no_run
 //! # #[cfg(feature = "atomic")]
-//! # use bbqueue::atomic::{BBBuffer, ConstBBBuffer, consts::*};
+//! # use bbqueue::atomic::{BBBuffer, ConstBBBuffer};
 //! # #[cfg(not(feature = "atomic"))]
-//! # use bbqueue::cm_mutex::{BBBuffer, ConstBBBuffer, consts::*};
+//! # use bbqueue::cm_mutex::{BBBuffer, ConstBBBuffer};
 //! #
 //! // Create a buffer with six elements
-//! static BB: BBBuffer<U6> = BBBuffer( ConstBBBuffer::new() );
+//! static BB: BBBuffer<6> = BBBuffer( ConstBBBuffer::new() );
 //!
 //! fn main() {
 //!     // Split the bbqueue into producer and consumer halves.
@@ -130,8 +130,6 @@ pub mod framed;
 mod vusize;
 
 use core::result::Result as CoreResult;
-
-pub use generic_array::ArrayLength;
 
 /// Result type used by the `BBQueue` interfaces
 pub type Result<T> = CoreResult<T, Error>;


### PR DESCRIPTION
This also changes `capacity()` to a `const fn` as it now just returns `N`.

I was hoping to have either `u8` or `u16` be the index size, but until const-generics gets stabalized enough to do the below, `usize` will have to be the way to go.
```rust 
struct Test<const N: u8> ([u8; N as usize]);
```

heapless noted it as a micro-optimization anyway https://github.com/japaric/heapless/pull/208