### PR TITLE
Post-v0.5.0 fixup

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -13,9 +13,6 @@ jobs:
       matrix:
         include:
           - rust: stable
-            features: atomic
-            nodefault: "--no-default-features"
-          - rust: stable
             features: thumbv6
             nodefault: "--no-default-features"
           - rust: stable

--- a/.github/workflows/embedded-builds.yml
+++ b/.github/workflows/embedded-builds.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - feature: atomic
+          - features: ""
             target: thumbv7em-none-eabihf
             rust: stable
           - feature: thumbv6

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -125,9 +125,7 @@ impl<'a, const N: usize> BBBuffer<N> {
     ///
     /// NOTE:  If the `thumbv6` feature is selected, this function takes a short critical
     /// section while splitting.
-    pub fn try_split_framed(
-        &'a self,
-    ) -> Result<(FrameProducer<'a, N>, FrameConsumer<'a, N>)> {
+    pub fn try_split_framed(&'a self) -> Result<(FrameProducer<'a, N>, FrameConsumer<'a, N>)> {
         let (producer, consumer) = self.try_split()?;
         Ok((FrameProducer { producer }, FrameConsumer { consumer }))
     }


### PR DESCRIPTION
Small non-functional fixes to tests and formatting that were missed in the v0.5.0 release