### PR TITLE
Feat/async support

### DIFF
--- a/bbqtest/Cargo.toml
+++ b/bbqtest/Cargo.toml
@@ -19,6 +19,8 @@ crossbeam-utils = "0.7"
 crossbeam = "0.7"
 heapless = "0.7"
 cfg-if = "0.1"
+futures = "0.3"
+
 
 [[bench]]
 name = "benches"

--- a/bbqtest/src/async_usage.rs
+++ b/bbqtest/src/async_usage.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+mod tests {
+    use bbqueue::BBBuffer;
+    use futures::executor::block_on;
+
+    #[test]
+    fn test_read() {
+        let bb: BBBuffer<6> = BBBuffer::new();
+        let (mut prod, mut cons) = bb.try_split().unwrap();
+
+        {
+            let mut grant = prod.grant_exact(4).unwrap();
+            let buf = grant.buf();
+            buf[0] = 0xDE;
+            buf[1] = 0xAD;
+            buf[2] = 0xC0;
+            buf[3] = 0xDE;
+            grant.commit(4);
+        }
+
+        let r_grant = block_on(cons.read_async()).unwrap();
+
+        assert_eq!(4, r_grant.len());
+        assert_eq!(r_grant[0], 0xDE);
+        assert_eq!(r_grant[1], 0xAD);
+        assert_eq!(r_grant[2], 0xC0);
+        assert_eq!(r_grant[3], 0xDE);
+    }
+
+    #[test]
+    fn test_write() {
+        let bb: BBBuffer<6> = BBBuffer::new();
+        let (mut prod, mut cons) = bb.try_split().unwrap();
+
+        let mut w_grant = block_on(prod.grant_exact_async(4)).unwrap();
+        assert_eq!(4, w_grant.len());
+        w_grant[0] = 0xDE;
+        w_grant[1] = 0xAD;
+        w_grant[2] = 0xC0;
+        w_grant[3] = 0xDE;
+        w_grant.commit(4);
+
+        let grant = cons.read().unwrap();
+        let rx_buf = grant.buf();
+        assert_eq!(4, rx_buf.len());
+        assert_eq!(rx_buf[0], 0xDE);
+        assert_eq!(rx_buf[1], 0xAD);
+        assert_eq!(rx_buf[2], 0xC0);
+        assert_eq!(rx_buf[3], 0xDE);
+    }
+}

--- a/bbqtest/src/lib.rs
+++ b/bbqtest/src/lib.rs
@@ -1,6 +1,7 @@
 //! NOTE: this crate is really just a shim for testing
 //! the other no-std crate.
 
+mod async_usage;
 mod framed;
 mod multi_thread;
 mod ring_around_the_senders;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = { version = "0.6.0", optional = true }
+embassy-sync = { version = "0.1.0" } #, optional = true }
 
 [features]
 thumbv6 = ["cortex-m"]

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -16,6 +16,8 @@ use core::{
         Ordering::{AcqRel, Acquire, Release},
     },
 };
+use embassy_sync::waitqueue::WakerRegistration;
+
 #[derive(Debug)]
 /// A backing structure for a BBQueue. Can be used to create either
 /// a BBQueue or a split Producer/Consumer pair
@@ -46,6 +48,12 @@ pub struct BBBuffer<const N: usize> {
 
     /// Is there an active write grant?
     write_in_progress: AtomicBool,
+
+    /// Read waker for async support
+    read_waker: WakerRegistration,
+
+    /// Write waker for async support
+    write_waker: WakerRegistration,
 
     /// Have we already split?
     already_split: AtomicBool,


### PR DESCRIPTION
Initial draft for async support. Just want your input before continuing/cleaning up. My experience with async is pretty limited so feedback and comments are more than welcomed!

I diverted a bit from the [previous work](https://github.com/jamesmunns/bbqueue/pull/86) API since I wanted to keep the flexibility.
This async api is as close as possible to the sync one.


**Note:** I've added [embassy-sync](https://crates.io/crates/embassy-sync) as a dependency since I'm used to embassy's libraries and just wanted to quickly prototype, but I can understand if you prefer to avoid adding dependencies. Also note that it's dependent on [critical-section](https://crates.io/crates/critical-section), thus an implementation is required if not on std.

Status:

- [x] Basic implementation
- [x] Basic tests
- [ ] Add Frame flavor implementation
- [ ] Cancellation tests
- [ ] Test on MSRV, gate behind feature if necessary
- [ ] Complete API documentation
- [ ] Fix edge case if user request a buffer bigger than N in async api.