### PR TITLE
Use abstract critical sections for thumbv6

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,10 +15,10 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cortex-m = { version = "0.6.0", optional = true }
+critical-section = { version = "1.1", optional = true }
 
 [features]
-thumbv6 = ["cortex-m"]
+thumbv6 = ["critical-section"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -1101,11 +1101,11 @@ mod atomic {
         AtomicBool, AtomicUsize,
         Ordering::{self, Acquire, Release},
     };
-    use cortex_m::interrupt::free;
+    use critical_section::with;
 
     #[inline(always)]
     pub fn fetch_add(atomic: &AtomicUsize, val: usize, _order: Ordering) -> usize {
-        free(|_| {
+        with(|_| {
             let prev = atomic.load(Acquire);
             atomic.store(prev.wrapping_add(val), Release);
             prev
@@ -1114,7 +1114,7 @@ mod atomic {
 
     #[inline(always)]
     pub fn fetch_sub(atomic: &AtomicUsize, val: usize, _order: Ordering) -> usize {
-        free(|_| {
+        with(|_| {
             let prev = atomic.load(Acquire);
             atomic.store(prev.wrapping_sub(val), Release);
             prev
@@ -1123,7 +1123,7 @@ mod atomic {
 
     #[inline(always)]
     pub fn swap(atomic: &AtomicBool, val: bool, _order: Ordering) -> bool {
-        free(|_| {
+        with(|_| {
             let prev = atomic.load(Acquire);
             atomic.store(val, Release);
             prev

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -92,8 +92,11 @@
 //!
 //! This crate contains special support for Cortex-M0(+) targets with the `thumbv6` feature. By
 //! enabling the feature, unsupported atomic operations will be replaced with critical sections
-//! implemented by disabling interrupts. The critical sections are very short, a few instructions at
-//! most, so they should make no difference to most applications.
+//! using the `critical_section` crate. The critical sections are very short, a few instructions at
+//! most, so they should make no difference to most applications.  When using this feature an
+//! implementation must be provided for the `critical_section` crate.  A single core version that
+//! disables interrupts is available on the `cortex_m` crate by enabling the feature
+//! `critical-section-single-core` on that crate.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]


### PR DESCRIPTION
This changes the critical sections required for thumbv6 to use the abstraction provided by the [`critical_section`](https://docs.rs/critical-section/latest/critical_section/) crate.  The context here is the RP2040 micocontroller, which is a two core Cortex-M0+ device, so just disabling interrupts on the current core is not sufficient when a bbqueue is used to communicate between cores.  However, the [HAL](https://docs.rs/rp2040-hal/latest/rp2040_hal/) provides an implementation of a critical section hooking into the abstraction above to handle this kind of case.

With this change, using bbqueue on single core thumbv6 target (equivalent to the current behavior) looks like:

```toml
[dependencies]
bbqueue = { version = "0.5", features = ["thumbv6"] }
cortex-m =  { version = "0.7.6", features = ["critical-section-single-core"] }
```

Or for a RP2040 in multi-core mode:

```toml
[dependencies]
bbqueue = { version = "0.5", features = ["thumbv6"] }
rp2040-hal = { version = "0.8.0", features=["critical-section-impl"] }
```
