### PR TITLE
feat: Unsafe constructors for producers and consumers

### DIFF
--- a/core/src/bbbuffer.rs
+++ b/core/src/bbbuffer.rs
@@ -306,6 +306,8 @@ pub struct Producer<'a, const N: usize> {
     pd: PhantomData<&'a ()>,
 }
 
+unsafe impl<'a, const N: usize> Send for Producer<'a, N> {}
+
 impl<'a, const N: usize> Producer<'a, N> {
     /// Create a `Producer` from a non null pointer to a [`BBBuffer`].
     ///
@@ -322,11 +324,6 @@ impl<'a, const N: usize> Producer<'a, N> {
             pd: PhantomData,
         }
     }
-}
-
-unsafe impl<'a, const N: usize> Send for Producer<'a, N> {}
-
-impl<'a, const N: usize> Producer<'a, N> {
     /// Request a writable, contiguous section of memory of exactly
     /// `sz` bytes. If the buffer size requested is not available,
     /// an error will be returned.
@@ -529,6 +526,8 @@ pub struct Consumer<'a, const N: usize> {
     pd: PhantomData<&'a ()>,
 }
 
+unsafe impl<'a, const N: usize> Send for Consumer<'a, N> {}
+
 impl<'a, const N: usize> Consumer<'a, N> {
     /// Create a `Consumer` from a non null pointer to a [`BBBuffer`].
     ///
@@ -545,11 +544,6 @@ impl<'a, const N: usize> Consumer<'a, N> {
             pd: PhantomData,
         }
     }
-}
-
-unsafe impl<'a, const N: usize> Send for Consumer<'a, N> {}
-
-impl<'a, const N: usize> Consumer<'a, N> {
     /// Obtains a contiguous slice of committed bytes. This slice may not
     /// contain ALL available bytes, if the writer has wrapped around. The
     /// remaining bytes will be available after all readable bytes are

--- a/core/src/framed.rs
+++ b/core/src/framed.rs
@@ -88,6 +88,21 @@ pub struct FrameProducer<'a, const N: usize> {
 }
 
 impl<'a, const N: usize> FrameProducer<'a, N> {
+    /// Create a `FrameProducer` from a non null pointer to a [`BBBuffer`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the [`BBBuffer`] was previously initialized. See
+    /// [`BBBUffer::try_split_framed`]
+    ///
+    /// [`BBBuffer`]: crate::BBBuffer
+    /// [`BBBuffer::try_split_framed`]: crate::BBBuffer::try_split_framed
+    pub unsafe fn new_unchecked(producer: Producer<'a, N>) -> Self {
+        Self { producer }
+    }
+}
+
+impl<'a, const N: usize> FrameProducer<'a, N> {
     /// Receive a grant for a frame with a maximum size of `max_sz` in bytes.
     ///
     /// This size does not include the size of the frame header. The exact size
@@ -104,6 +119,21 @@ impl<'a, const N: usize> FrameProducer<'a, N> {
 /// A consumer of Framed data
 pub struct FrameConsumer<'a, const N: usize> {
     pub(crate) consumer: Consumer<'a, N>,
+}
+
+impl<'a, const N: usize> FrameConsumer<'a, N> {
+    /// Create a `FrameConsumer` from a non null pointer to a [`BBBuffer`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the [`BBBuffer`] was previously initialized. See
+    /// [`BBBUffer::try_split_framed`]
+    ///
+    /// [`BBBuffer`]: crate::BBBuffer
+    /// [`BBBuffer::try_split_framed`]: crate::BBBuffer::try_split_framed
+    pub unsafe fn new_unchecked(consumer: Consumer<'a, N>) -> Self {
+        Self { consumer }
+    }
 }
 
 impl<'a, const N: usize> FrameConsumer<'a, N> {

--- a/core/src/framed.rs
+++ b/core/src/framed.rs
@@ -100,9 +100,6 @@ impl<'a, const N: usize> FrameProducer<'a, N> {
     pub unsafe fn new_unchecked(producer: Producer<'a, N>) -> Self {
         Self { producer }
     }
-}
-
-impl<'a, const N: usize> FrameProducer<'a, N> {
     /// Receive a grant for a frame with a maximum size of `max_sz` in bytes.
     ///
     /// This size does not include the size of the frame header. The exact size
@@ -134,9 +131,6 @@ impl<'a, const N: usize> FrameConsumer<'a, N> {
     pub unsafe fn new_unchecked(consumer: Consumer<'a, N>) -> Self {
         Self { consumer }
     }
-}
-
-impl<'a, const N: usize> FrameConsumer<'a, N> {
     /// Obtain the next available frame, if any
     pub fn read(&mut self) -> Option<FrameGrantR<'a, N>> {
         // Get all available bytes. We never wrap a frame around,


### PR DESCRIPTION
Related to https://github.com/jamesmunns/bbqueue/issues/67, this would allow to a shared memory region between two processes without being initialised twice. Of course, is marked as `unsafe`