### PR TITLE
Add ArcBBQueue framed constructors with explicit LenHeader

### DIFF
--- a/bbqueue/src/queue.rs
+++ b/bbqueue/src/queue.rs
@@ -145,6 +145,34 @@ impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
         }
     }
 
+    /// Create a new [`FramedProducer`] for this [`BBQueue`] with a custom
+    /// frame length header type.
+    ///
+    /// This can be used to support large frame sizes by selecting a larger
+    /// [`LenHeader`] type such as `usize`.
+    pub fn framed_producer_with_header<H: crate::prod_cons::framed::LenHeader>(
+        &self,
+    ) -> FramedProducer<alloc::sync::Arc<BBQueue<S, C, N>>, H> {
+        FramedProducer {
+            bbq: self.0.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    /// Create a new [`FramedConsumer`] for this [`BBQueue`] with a custom
+    /// frame length header type.
+    ///
+    /// This can be used to support large frame sizes by selecting a larger
+    /// [`LenHeader`] type such as `usize`.
+    pub fn framed_consumer_with_header<H: crate::prod_cons::framed::LenHeader>(
+        &self,
+    ) -> FramedConsumer<alloc::sync::Arc<BBQueue<S, C, N>>, H> {
+        FramedConsumer {
+            bbq: self.0.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
     /// Create a new [`StreamProducer`] for this [`BBQueue`]
     ///
     /// Although mixing stream and framed consumer/producers will not result in UB,

--- a/bbqueue/src/queue.rs
+++ b/bbqueue/src/queue.rs
@@ -149,7 +149,16 @@ impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
     /// frame length header type.
     ///
     /// This can be used to support large frame sizes by selecting a larger
-    /// [`LenHeader`] type such as `usize`.
+    /// [`LenHeader`](crate::prod_cons::framed::LenHeader) type such as
+    /// `usize`.
+    ///
+    /// The `H` header type MUST match the `H` used to create the paired
+    /// [`FramedConsumer`] (typically via
+    /// [`framed_consumer_with_header`](Self::framed_consumer_with_header)).
+    /// Header width is not stored in the queue itself, so a mismatch will
+    /// silently corrupt framing rather than producing a compile-time or
+    /// runtime error. Mixing framed with stream producers/consumers will not
+    /// result in UB either, but will also not work correctly.
     pub fn framed_producer_with_header<H: crate::prod_cons::framed::LenHeader>(
         &self,
     ) -> FramedProducer<alloc::sync::Arc<BBQueue<S, C, N>>, H> {
@@ -163,7 +172,16 @@ impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
     /// frame length header type.
     ///
     /// This can be used to support large frame sizes by selecting a larger
-    /// [`LenHeader`] type such as `usize`.
+    /// [`LenHeader`](crate::prod_cons::framed::LenHeader) type such as
+    /// `usize`.
+    ///
+    /// The `H` header type MUST match the `H` used to create the paired
+    /// [`FramedProducer`] (typically via
+    /// [`framed_producer_with_header`](Self::framed_producer_with_header)).
+    /// Header width is not stored in the queue itself, so a mismatch will
+    /// silently corrupt framing rather than producing a compile-time or
+    /// runtime error. Mixing framed with stream producers/consumers will not
+    /// result in UB either, but will also not work correctly.
     pub fn framed_consumer_with_header<H: crate::prod_cons::framed::LenHeader>(
         &self,
     ) -> FramedConsumer<alloc::sync::Arc<BBQueue<S, C, N>>, H> {


### PR DESCRIPTION
The existing framed_producer() and framed_consumer() methods on ArcBBQueue return handles hardcoded to u16 frame headers, which limits individual frames to 64 KiB. All the underlying types (FramedProducer, FramedConsumer, FramedGrantW, FramedGrantR) are already generic over the LenHeader trait, but the ArcBBQueue convenience constructors don't expose that generic. This adds framed_producer_with_header() and framed_consumer_with_header() companion methods that let the caller select the header type, such as usize for workloads that need frames larger than 64 KiB. The existing default-u16 methods are untouched.

In support of this upgrade; would resolve need for our fork in production:
https://github.com/elodin-sys/elodin/pull/610